### PR TITLE
Support normal quote character for custom checkbox

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -7531,6 +7531,9 @@ li[data-task="S"]>p>input:checked,
 input[data-task="“"]:checked,
 li[data-task="“"]>input:checked,
 li[data-task="“"]>p>input:checked,
+input[data-task="\""]:checked,
+li[data-task="\""]>input:checked,
+li[data-task="\""]>p>input:checked,
 input[data-task="c"]:checked,
 li[data-task="c"]>input:checked,
 li[data-task="c"]>p>input:checked,
@@ -7682,7 +7685,10 @@ li[data-task="c"]>p>input:checked {
 
 input[data-task="“"]:checked,
 li[data-task="“"]>input:checked,
-li[data-task="“"]>p>input:checked {
+li[data-task="“"]>p>input:checked,
+input[data-task="\""]:checked,
+li[data-task="\""]>input:checked,
+li[data-task="\""]>p>input:checked{
     --checkbox-color-hover: var(--color-purple);
     color: var(--color-purple);
     -webkit-mask-image: url('data:image/svg+xml;utf8,<?xml version="1.0" encoding="UTF-8"?><svg id="svg0" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><defs><style>.cls-1{fill:none;}</style></defs><rect class="cls-1" width="16" height="16"/><path d="M2.46,4.19c.94-1.01,2.35-1.53,4.21-1.53h.67v1.88l-.54,.11c-.91,.18-1.55,.54-1.89,1.07-.18,.28-.28,.61-.29,.94h2.05c.18,0,.35,.07,.47,.2,.13,.13,.2,.29,.2,.47v4.67c0,.74-.6,1.33-1.33,1.33H2c-.18,0-.35-.07-.47-.2-.13-.12-.2-.29-.2-.47V7.39c0-.07-.13-1.83,1.13-3.19ZM13.33,13.33h-4c-.18,0-.35-.07-.47-.2-.13-.12-.2-.29-.2-.47V7.39c0-.07-.13-1.83,1.13-3.19,.94-1.01,2.35-1.53,4.21-1.53h.67v1.88l-.54,.11c-.91,.18-1.55,.54-1.89,1.07-.18,.28-.28,.61-.29,.94h2.05c.18,0,.35,.07,.47,.2,.12,.13,.2,.29,.2,.47v4.67c0,.74-.6,1.33-1.33,1.33Z"/></svg>');


### PR DESCRIPTION
For the custom "quote" checkbox style, it requires writing `- [“]` using the curly quote character, which is not easy to type. This allows for using a normal quote `- ["]` which is easier to type and is [already supported by the Obsidian Minimal theme](https://github.com/kepano/obsidian-minimal/blob/master/src/scss/features/checklist-icons.scss#L146).