### PR TITLE
Adaption of Grid Background to Export Image Plugin

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -6797,7 +6797,7 @@ body {
 }
 
 .editor-grid-background-pattren .workspace-leaf-content[data-type="markdown"],
-.export-image-preview-container.markdown-rendered {
+.export-image-preview-container.markdown-rendered { /*Adaptive to the Export Image Plugin*/
     background-image: linear-gradient(to right, var(--grid-background-pattern-color) 1px, transparent 1px),
         linear-gradient(to bottom, var(--grid-background-pattern-color) 1px, transparent 1px);
     background-size: var(--grid-background-pattern-size) var(--grid-background-pattern-size);

--- a/theme.css
+++ b/theme.css
@@ -6796,7 +6796,8 @@ body {
     --grid-background-pattern-color: var(--background-modifier-border);
 }
 
-.editor-grid-background-pattren .workspace-leaf-content[data-type="markdown"] {
+.editor-grid-background-pattren .workspace-leaf-content[data-type="markdown"],
+.export-image-preview-container.markdown-rendered {
     background-image: linear-gradient(to right, var(--grid-background-pattern-color) 1px, transparent 1px),
         linear-gradient(to bottom, var(--grid-background-pattern-color) 1px, transparent 1px);
     background-size: var(--grid-background-pattern-size) var(--grid-background-pattern-size);


### PR DESCRIPTION
I have Enabled the grid background to be displayed in the export results of the export image plugin, just like this:

![](https://figure-bed123.oss-cn-beijing.aliyuncs.com/202410182339583.png)

I thought there would be some people like me who, when using the Export Image plugin, would like to export the grid background as well, so I did the adaptation to Export Image for the Border theme, albeit at the cost of adding a single line of code.

If you also think this is a meaningful PR for Border, please accept it; and if you don't think it is, feel free to close the PR. Thank you for creating such a beautiful Obsidian theme!